### PR TITLE
Only allow wildcards which form an entire path segment.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,8 @@ Changes:
   [`#17 <https://github.com/pyca/service_identity/pull/17>`_]
 - ``cryptography.x509`` backend for verifying certificates.
   [`#18 <https://github.com/pyca/service_identity/pull/18>`_]
+- Do not allow wildcards (``*``) that are not the leftmost label in a certificate.
+  [`#19 <https://github.com/pyca/service_identity/pull/19>`_]
 
 
 ----

--- a/src/service_identity/_common.py
+++ b/src/service_identity/_common.py
@@ -365,20 +365,7 @@ def _hostname_matches(cert_pattern, actual_hostname):
         if actual_head.startswith(b"xn--"):
             return False
 
-        if cert_head == b"*":
-            return True
-
-        start, end = cert_head.split(b"*")
-        if start == b"":
-            # *oo
-            return actual_head.endswith(end)
-        elif end == b"":
-            # f*
-            return actual_head.startswith(start)
-        else:
-            # f*o
-            return actual_head.startswith(start) and actual_head.endswith(end)
-
+        return cert_head == b"*" or cert_head == actual_head
     else:
         return cert_pattern == actual_hostname
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -223,10 +223,6 @@ class TestDNS_ID(object):
         for cert, actual in [
             (b"www.example.com", b"www.example.com"),
             (b"*.example.com", b"www.example.com"),
-            (b"xxx*.example.com", b"xxxwww.example.com"),
-            (b"f*.example.com", b"foo.example.com"),
-            (b"*oo.bar.com", b"foo.bar.com"),
-            (b"fo*oo.bar.com", b"fooooo.bar.com"),
         ]:
             assert _hostname_matches(cert, actual)
 
@@ -241,6 +237,10 @@ class TestDNS_ID(object):
             (b"*.bar.com", b"foo.baz.com"),
             (b"*.bar.com", b"bar.com"),
             (b"x*.example.com", b"xn--gtter-jua.example.com"),
+            (b"xxx*.example.com", b"xxxwww.example.com"),
+            (b"f*.example.com", b"foo.example.com"),
+            (b"*oo.bar.com", b"foo.bar.com"),
+            (b"fo*oo.bar.com", b"fooooo.bar.com"),
         ]:
             assert not _hostname_matches(cert, actual)
 


### PR DESCRIPTION
No weird sub-wildcards