### PR TITLE
Fix typo

### DIFF
--- a/src/service_identity/_common.py
+++ b/src/service_identity/_common.py
@@ -388,7 +388,7 @@ def _validate_pattern(cert_pattern):
     parts = cert_pattern.split(b".")
     if len(parts) < 3:
         raise CertificateError(
-            "Certificate's DNS-ID {0!r} hast too few host components for "
+            "Certificate's DNS-ID {0!r} has too few host components for "
             "wildcard usage."
             .format(cert_pattern)
         )


### PR DESCRIPTION
Fix minor typo in an exception.

Really I'm just making this PR so a new build kicks off and runs against the latest `pyasn1` and `pyasn1-modules` since it's been months since the last build, to double check that they're safe to upgrade to the latest versions.