### PR TITLE
Workaround for setuptools install_requires bug with pyasn1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,10 @@ CLASSIFIERS = [
 ]
 INSTALL_REQUIRES = [
     "attrs>=16.0.0",
-    "pyasn1",
     "pyasn1-modules",
+    # Place pyasn1 after pyasn1-modules to workaround setuptools install bug:
+    # https://github.com/pypa/setuptools/issues/498
+    "pyasn1",
     "pyopenssl>=0.12",
 ]
 EXTRAS_REQUIRE = {


### PR DESCRIPTION
When installing service_identity with `setup.py install` the order of
the install_requires directive causes setuptools to fail to install
`pyasn1` with the following error message:

    error: The 'pyasn1' distribution was not found and is required by service-identity

The workaround is to switch the order of `pyasn1` and `pyasn1-modules` in
the install_requires directive.

Setuptools issue: https://github.com/pypa/setuptools/issues/498